### PR TITLE
Fix the amount round

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -25,7 +25,7 @@ class PayProPaymentModuleFrontController extends ModuleFrontController {
 		$callbackUrl = $this->context->link->getModuleLink('paypro', 'callback');
 
 		$data = [
-			'amount' => round($cart->getOrderTotal(true, Cart::BOTH) * 100, 2),
+			'amount' => (int) (round($cart->getOrderTotal(true, Cart::BOTH) * 100, 0)),
 			'pay_method' => $payMethod,
 			'return_url' => $redirectUrl,
 			'cancel_url' => $redirectUrl,


### PR DESCRIPTION
The issue was:

> We received order amount of 18.99999999999998 which is invalid for our API. The plugin should round correctly to two decimal points.

According to what I checked Prestashop rounds this price to 18.90, so you see 18.90 during the payment, but when we convert data to JSON, it became `1889.999999999999772626324556767940521240234375`. I moved the round to the last place in expression, and it fixes the issue.