### PR TITLE
Remove canceled status receiving before approved

### DIFF
--- a/paypro.php
+++ b/paypro.php
@@ -152,8 +152,8 @@ class PayPro extends PaymentModule {
 				case 'completed':
 					$status = Configuration::get('PS_OS_PAYMENT');
 					break;
-				default:
-					$status = Configuration::get('PS_OS_BANKWIRE');
+				case 'cancelled':
+					$status = Configuration::get('PS_OS_ERROR');
 			}
 
 			// Order update


### PR DESCRIPTION
The problem is:

> The status of the Order in Prestashop goes from Canceled to Payment accepted. While the payment was never canceled.

We had a _PS_OS_CANCELED_  returned by default before. At the same time, _PS_OS_CANCELED_ setting corresponds to `merchant canceled the order` not `payment was canceled`. The customer also receives an email that his order was canceled by the merchant. 

Here is the list of all possible status changes:
```
_PS_OS_CHEQUE_: Awaiting check payment
_PS_OS_PAYMENT_: Payment accepted
_PS_OS_PREPARATION_: Processing in progress
_PS_OS_SHIPPING_: Shipped
_PS_OS_DELIVERED_`: Delivered
_PS_OS_CANCELED_: Cancelled(order by the merchant)
_PS_OS_REFUND_: Refunded
_PS_OS_ERROR_: Payment error
_PS_OS_OUTOFSTOCK_PAID_: On backorder (paid)
_PS_OS_OUTOFSTOCK_UNPAID_: On backorder (not paid)
_PS_OS_BANKWIRE_: Awaiting bank wire payment
_PS_OS_COD_VALIDATION_: Awaiting cash on delivery validation
```

The statuses which we are interested in are _PS_OS_PAYMENT_, _PS_OS_BANKWIRE_, and probably _PS_OS_ERROR_.

Not sure, if we should handle _PS_OS_ERROR_, we can put it to error when we receive status 'cancelled' from our API). For now, I decided not to add this one. 