### PR TITLE
Add new status 'Awaiting PayPro payment'

### DIFF
--- a/paypro.php
+++ b/paypro.php
@@ -71,47 +71,47 @@ class PayPro extends PaymentModule {
 
 		// Check if order state exist
 		$stateExist = false;
-        foreach ($states as $state) {
-            if (in_array($statusName, $state)) {
-                $stateExist = true;
-                break;
-            }
-        }
+		foreach ($states as $state) {
+			if (in_array($statusName, $state)) {
+				$stateExist = true;
+				break;
+			}
+		}
 
-        // If the state does not exist, we create it
-        if (!$stateExist) {
-            $orderState = new OrderState();
-            $orderState->color = '#4169E1';
-            $orderState->send_email = false;
-            $orderState->module_name = $this->name;
-            $orderState->name = array();
+		// If the state does not exist, we create it
+		if (!$stateExist) {
+			$orderState = new OrderState();
+			$orderState->color = '#4169E1';
+			$orderState->send_email = false;
+			$orderState->module_name = $this->name;
+			$orderState->name = array();
 
-            $languages = Language::getLanguages(false);
+			$languages = Language::getLanguages(false);
 
-            foreach ($languages as $language)
-                $orderState->name[ $language['id_lang'] ] = $statusName;
+			foreach ($languages as $language)
+				$orderState->name[ $language['id_lang'] ] = $statusName;
 
-            // Update object
-            $orderState->add();
-        }
+			// Update object
+			$orderState->add();
+		}
 
-        return true;
+		return true;
 	}
 
-    private function removeOrderStatus() {
-        $statusName = $this->l('Awaiting PayPro payment');
-        $states = OrderState::getOrderStates((int)$this->context->language->id);
+	private function removeOrderStatus() {
+		$statusName = $this->l('Awaiting PayPro payment');
+		$states = OrderState::getOrderStates((int)$this->context->language->id);
 
-        foreach ($states as $state) {
-            if (in_array($statusName, $state)) {
-                $orderState = new OrderState($state['id_order_state']);
-                $orderState->deleted = 1;
-                $orderState->update();
-            }
-        }
+		foreach ($states as $state) {
+			if (in_array($statusName, $state)) {
+				$orderState = new OrderState($state['id_order_state']);
+				$orderState->deleted = 1;
+				$orderState->update();
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
 	public function getContent() {
 		// Check post
@@ -196,10 +196,10 @@ class PayPro extends PaymentModule {
 		$states = OrderState::getOrderStates((int)$this->context->language->id);
 
 		foreach ($states as $state) {
-            if (in_array($statusName, $state)) {
-                return $state['id_order_state'];
-            }
-        }
+			if (in_array($statusName, $state)) {
+				return $state['id_order_state'];
+			}
+		}
 	}
 
 	public function processPayment($cartID, $paymentHash) {
@@ -214,8 +214,8 @@ class PayPro extends PaymentModule {
 				case 'cancelled':
 					$status = Configuration::get('PS_OS_ERROR');
 					break;
-                default:
-                    $status = $this->getOrderStatusId();
+				default:
+					$status = $this->getOrderStatusId();
 			}
 
 			// Order update

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -16,6 +16,7 @@ $_MODULE['<{paypro}prestashop>paypro_80ccbf6bc10ab01a0df43589b2361e98'] = 'Autom
 $_MODULE['<{paypro}prestashop>paypro_4bb78080b7dd7488ad47bea58c86b6c3'] = 'Sofort Digital';
 $_MODULE['<{paypro}prestashop>paypro_f0f404e78d5ce50fcec2a07aa17977d9'] = 'Sofort Physical';
 $_MODULE['<{paypro}prestashop>paypro_89fc0d6fe12b0e0c1af5c7a0373435a6'] = 'Visa';
+$_MODULE['<{paypro}prestashop>paypro_389d78f71b874c2c4e27edea32e4d8be'] = 'Wachten op PayPro betaling';
 $_MODULE['<{paypro}prestashop>paypro_c888438d14855d7d96a2724ee9c306bd'] = 'Instellingen gewijzigd';
 $_MODULE['<{paypro}prestashop>validation_e2b7dec8fa4b498156dfee6e4c84b156'] = 'Deze betaalmethode is niet beschikbaar';
 $_MODULE['<{paypro}prestashop>issuers_c5ddab2a7bb11a7ee8f5a131db40bfae'] = 'Selecteer je bank';


### PR DESCRIPTION
After the latest update #3, we've got a bug that if the status is not 'completed' or 'canceled', it would return 500 error as `$status` is undefined.

@paypro-leon and I decided to add a new status as the list of exciting ones didn't correspond to what we need.