### PR TITLE
Add order to payment description

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -32,7 +32,7 @@ class PayProPaymentModuleFrontController extends ModuleFrontController {
 			'return_url' => $redirectUrl,
 			'cancel_url' => $cancelUrl,
 			'postback_url' => $callbackUrl,
-			'description' => strval($cart->id),
+			'description' => 'Order: ' . strval($cart->id),
 			'locale' => strtoupper($language->iso_code),
 			'custom' => strval($cart->id),
 			'consumer_email' => $customer->email,


### PR DESCRIPTION
Minimal description length for PE::Payment should 3. For new merchants, it can be smaller. We need to fix it.